### PR TITLE
Allow atomic operations up to 32 bits

### DIFF
--- a/src/librustc_back/target/armv5te_unknown_linux_gnueabi.rs
+++ b/src/librustc_back/target/armv5te_unknown_linux_gnueabi.rs
@@ -27,8 +27,12 @@ pub fn target() -> TargetResult {
 
         options: TargetOptions {
             features: "+soft-float,+strict-align".to_string(),
-            // No atomic instructions on ARMv5
-            max_atomic_width: Some(0),
+
+            // Atomic operations provided when linked with libgcc.
+            // FIXME: If the following PR is merged, the atomic operations would be
+            // provided by compiler-builtins instead with no change of behavior:
+            // https://github.com/rust-lang-nursery/compiler-builtins/pull/115/files
+            max_atomic_width: Some(32),
             abi_blacklist: super::arm_base::abi_blacklist(),
             .. base
         }


### PR DESCRIPTION
The ARMv5te platform does not have instruction-level support for atomics, however the kernel provides [user space helpers](https://www.kernel.org/doc/Documentation/arm/kernel_user_helpers.txt) which can be used to perform atomic operations. When linked with `libc`, the atomic symbols needed by Rust will be provided, rather than CPU level intrinsics.

32-bit versions of these kernel level helpers were introduced in Linux Kernel 2.6.12, and 64-bit version of these kernel level helpers were introduced in Linux Kernel 3.1. I have selected 32 bit versions as `std` currently only requires Linux version 2.6.18 and above as far as I am aware.

As this target is specifically `linux` and `gnueabi`, it is reasonable to assume the Linux Kernel and libc will be available for the target. There is a large performance penalty, as we are not using CPU level intrinsics, however this penalty is likely preferable to not having the target at all.

I have used this change in a custom target (along with `xargo`) to build `std`, as well as a number of higher level crates.